### PR TITLE
Allowing gns-sys to be built in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,10 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cexpr"
@@ -149,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,13 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]

--- a/gns-sys/Cargo.toml
+++ b/gns-sys/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["rlib", "staticlib"]
 
 [build-dependencies]
 bindgen = "0.69"
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.1.31", features = ["parallel"] }

--- a/gns-sys/Cargo.toml
+++ b/gns-sys/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["rlib", "staticlib"]
 
 [build-dependencies]
 bindgen = "0.69"
-cc = "1"
+cc = { version = "1.0", features = ["parallel"] }


### PR DESCRIPTION
As [documented here](https://docs.rs/cc/latest/cc/#parallel), the `cc` cargo requires a specific feature flag to toggle parallel compiling.   
By enabling parallel compiling, the compilation speed would increase by times.  