### PR TITLE
Add support for IPv4 addresses

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -40,7 +40,7 @@ fn server(port: u16) {
     let server = GnsSocket::new(&gns_global, &gns_utils)
         // **unwrap** must be banned in production.
         .unwrap()
-        .listen(Ipv6Addr::LOCALHOST, port)
+        .listen(Ipv6Addr::LOCALHOST.into(), port)
         // **unwrap** must be banned in production.
         .unwrap();
 
@@ -190,7 +190,7 @@ fn client(port: u16) {
     let client = GnsSocket::new(&gns_global, &gns_utils)
         // **unwrap** must be banned in production.
         .unwrap()
-        .connect(Ipv6Addr::LOCALHOST, port)
+        .connect(Ipv6Addr::LOCALHOST.into(), port)
         // **unwrap** must be banned in production.
         .unwrap();
 


### PR DESCRIPTION
Hey there, thanks for this crate!

I'm running MacOS and using a custom tun interface with an IPv4 address, and IPv6 compatible addresses don't seem to be working for me in that case.

This PR allows using IPv4 or IPv6.

I followed the logic here for IPv4 addresses in the Valve lib:
https://github.com/ValveSoftware/GameNetworkingSockets/blob/725e273c7442bac7a8bc903c0b210b1c15c34d92/include/steam/steamnetworkingtypes.h#L1898-L1899