### PR TITLE
Remove `MsgPtr` type guesswork

### DIFF
--- a/gns/src/lib.rs
+++ b/gns/src/lib.rs
@@ -934,10 +934,8 @@ impl Drop for GnsUtils {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
-type MsgPtr = *const u8;
-#[cfg(target_arch = "x86_64")]
-type MsgPtr = *const i8;
+type MsgPtr = *const ::std::os::raw::c_char;
+
 
 impl GnsUtils {
     #[inline]


### PR DESCRIPTION
The underlying `bindgen` generated code uses this `c_char` type from the Rust standard library. I believe this crate can use it, too, to avoid the `#[cfg]` branch.

In my case on MacOS / Apple Silicon, the type is wrong, as it needs to be `*const i8` instead of `*const u8`.

Might want to test this in other environments. I'm only able to check MacOS.