### PR TITLE
Use vcpkg/pkg-config to auto-determine link deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,8 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cmake",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -184,6 +186,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "prettyplease"
@@ -270,6 +278,11 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "git+https://github.com/mcgoo/vcpkg-rs.git#fa42994af157924e44223f2559a95c906e00c1fa"
 
 [[package]]
 name = "windows-targets"

--- a/gns-sys/Cargo.toml
+++ b/gns-sys/Cargo.toml
@@ -15,3 +15,6 @@ crate-type = ["rlib", "staticlib"]
 [build-dependencies]
 bindgen = "0.70"
 cmake = "0.1"
+pkg-config = "0.3"
+# GitHub repo has patches to support manifest mode that aren't published to crates.io yet
+vcpkg = { git = "https://github.com/mcgoo/vcpkg-rs.git" }


### PR DESCRIPTION
Instead of hardcoding a giant list of link dependencies, use tools like vcpkg (for MSVC) and pkg-config to pull link dependency information from dependencies themselves. This not only removes the need for a hardcoded list of link dependencies which can fall out of date, but also adds better support for cross-compilation, as pkg-config can be used to pull dependency information from other sysroots.

Additionally, this allows possibly older versions of e.g. protobuf (that don't have abseil deps) to be used if the system that is building doesn't have an updated protobuf (this keeps things much closer in line to the supported protobuf version from upstream GNS).