### PR TITLE
Shorten GNS directory under target/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "game-networking-sockets-sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen",
  "cmake",

--- a/gns-sys/Cargo.toml
+++ b/gns-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "game-networking-sockets-sys"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust bindings for Valve GameNetworkingSockets library."
 license.workspace = true

--- a/gns-sys/build.rs
+++ b/gns-sys/build.rs
@@ -283,7 +283,7 @@ fn main() {
         //  and _only_ on Windows. Upstream GameNetworkingSockets will only find vcpkg if it is
         //  cloned to the root of it's src/ dir; we may want to submit a patch that will let it
         //  find vcpkg elsewhere, to avoid cloning the src/ dir to OUT_DIR.
-        let new_dir = out_dir.join("GameNetworkingSockets");
+        let new_dir = out_dir.join("GNS");
         if new_dir.exists() {
             std::fs::remove_dir_all(&new_dir).unwrap();
         }


### PR DESCRIPTION
The crate name is now game-networking-sockets instead of gns. In order to offset
 this increase in length, use GNS instead of GameNetworkingSockets for the
 copied src/ directory under target/ on Windows.